### PR TITLE
Use version 9 of dts-bundle-generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "dts-bundle-generator": "^7.2.0"
+        "dts-bundle-generator": "^9.0.0"
       },
       "devDependencies": {
         "@parcel/packager-ts": "^2.10.3",
@@ -4502,11 +4502,11 @@
       "dev": true
     },
     "node_modules/dts-bundle-generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz",
-      "integrity": "sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-9.0.0.tgz",
+      "integrity": "sha512-4XPDOb+F1fkPrvqFL4hnNW2Edc3uiFxQDsK8gUMP8/45+QkA+dSOH0ZWZCKXEjA3ITVbPGV1li8oP8JE4Z/Y0g==",
       "dependencies": {
-        "typescript": ">=4.5.2",
+        "typescript": ">=5.0.2",
         "yargs": "^17.6.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bundle-declarations-webpack-plugin",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Webpack plugin which wraps https://www.npmjs.com/package/dts-bundle-generator/",
   "scripts": {
     "test": "export NODE_OPTIONS=--experimental-vm-modules;jest",
@@ -44,7 +44,7 @@
     "combine declarations"
   ],
   "dependencies": {
-    "dts-bundle-generator": "^7.2.0"
+    "dts-bundle-generator": "^9.0.0"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.10.3",


### PR DESCRIPTION
Breaking changes in the minimum supported typescript version, and the bundle output based on the 2 major version increases from `dts-bundle-generator`.

* [https://github.com/timocov/dts-bundle-generator/releases/tag/v8.0.0](https://github.com/timocov/dts-bundle-generator/releases/tag/v8.0.0)
* [https://github.com/timocov/dts-bundle-generator/releases/tag/v9.0.0](https://github.com/timocov/dts-bundle-generator/releases/tag/v9.0.0)