### PR TITLE
Fix that outputting empty d.ts file in Windows

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -16,14 +16,14 @@ export function compile(entries: EntryPointConfig[], { compilationOptions, remov
     return new Promise<Buffer>((resolve, reject) => {
         try {
             const raw = generateDtsBundle(entries, compilationOptions)
-                .flatMap(x => x.split(EOL));
+                .flatMap(x => x.split("\n").map(y => y.trim()));
             const dts = raw
                 .filter(l =>
                     !(removeEmptyLines && emptyLines.test(l))
                     && !(removeEmptyExports && emptyExports.test(l))
                     && !(removeRelativeReExport && relativeReExport.test(l))
                 )
-                .join(EOL);
+                .join("\n");
 
             resolve(Buffer.from(dts));
         } catch (err) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -16,7 +16,7 @@ export function compile(entries: EntryPointConfig[], { compilationOptions, remov
     return new Promise<Buffer>((resolve, reject) => {
         try {
             const raw = generateDtsBundle(entries, compilationOptions)
-                .flatMap(x => x.split("\n").map(y => y.trim()));
+                .flatMap(x => x.split("\n").map(y => y.trimEnd()));
             const dts = raw
                 .filter(l =>
                     !(removeEmptyLines && emptyLines.test(l))


### PR DESCRIPTION
The original compile() method split and join text by `EOL` constant of node, and in Windows, the `EOL` is `\r\n`.

However, most of editors and IDEs will auto strip `\r`, so the text sent to compile() method will not contains `\r` and has only `\n`. And currently this plugin use `EOL` (`\r\n`) to split code, so that it will failure to split to lines and whole code will be filtered, hence the `removeEmptyLines` options will remove all code and output an empty d.ts file.

This PR try to split and join codes with only `\n` so that can work with files only contains `\n` in Windows.