### PR TITLE
Resolves #15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, "20.10.0", "latest"  ]
+        node: [ "20.11.1", "latest"  ]
     name: Run tests on Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@master

--- a/package-lock.json
+++ b/package-lock.json
@@ -6614,9 +6614,9 @@
       "dev": true
     },
     "node_modules/msgpackr": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
-      "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bundle-declarations-webpack-plugin",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "description": "Webpack plugin which wraps https://www.npmjs.com/package/dts-bundle-generator/",
   "scripts": {
     "test": "export NODE_OPTIONS=--experimental-vm-modules;jest",

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,6 +20,8 @@ import type { EntryPointConfig, CompilationOptions } from "dts-bundle-generator"
     /**Remove `export * from "./somemodule"` relative re-exporting; this was added to work around a bug in `dts-bundle-generator` 
      * whereby re-exporting would lead to both the relative and qualified paths being included. */
     removeRelativeReExport?: boolean;
+    /**Override `.d.ts` bundling to run as part of the webpack compilation process in webpack's watch mode (slower but no false positives)  */
+    blockingWatch?: boolean;
 }
 
 /**Provides the default plugin options if omitted or partially omitted.*/

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,11 +8,16 @@ type WorkerData = {
     options: Options;
 };
 
-const {
-    entries,
-    options,
-}: WorkerData = workerData;
+try {
+    const {
+        entries,
+        options,
+    }: WorkerData = workerData;
 
-compile(entries, options).then(buffer => {
+    const buffer = await compile(entries, options)
     parentPort?.postMessage(buffer);
-});
+} catch (error) {
+    console.error(error);
+
+    throw error;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     ],
     "compilerOptions": {
         "target": "ES2020",
-        "module": "ES2020",
-        "moduleResolution": "Node10",
+        "module": "ES2022",
+        "moduleResolution": "Bundler",
         "baseUrl": "./src/",
         "rootDir": "./src/",
         "outDir": "./lib/",


### PR DESCRIPTION
Resolves #15

Adds support for `blockingWatch` option.

When `blockingWatch: true` - the webpack watch mode compilations will:
* wait for the `d.ts` bundling to complete before finalizing the build.  
* fail the entire build if `d.ts` bundling fails

Note that on larger, more complex builds the impact to performance in watch mode may become unbearable, so the default remains to run out of process in watch mode; the flag is just to support overriding the default behaviour where appropriate.