### PR TITLE
fix: include dev dependencies in npm ci command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           node-version: latest
           cache: npm
-      - run: npm ci
+      - run: npm ci --include=dev
       - run: npm publish
         if: ${{ !github.event.release.prerelease }}
         env:


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/release.yml` file to ensure that development dependencies are included during the continuous integration process.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24): Modified the `npm ci` command to include development dependencies by adding the `--include=dev` flag.