### PR TITLE
Fix package.json field for importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint": "eslint . --fix --cache"
   },
   "pre-commit": "lint",
-  "source": "src/index.ts",
+  "source": "./src/index.ts",
   "type": "module",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "targets": {
     "module": {
       "optimize": true


### PR DESCRIPTION
The lack of an `exports` property in package.json is producing import errors for me.  A test ESM script with BDWP v6.0.0: 

```javascript
import BundleDeclarationsWebpackPlugin from 'bundle-declarations-webpack-plugin';
new BundleDeclarationsWebpackPlugin();
```

returns this error

```
$ node asdf.mjs
node:internal/modules/esm/resolve:204
  const resolvedOption = FSLegacyMainResolve(pkgPath, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/.../node_modules/bundle-declarations-webpack-plugin/index.js' imported from /.../asdf.mjs

...(traceback) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v22.14.0
```

Modifying `node_modules/bundle-declarations-webpack-plugin/package.json` with this PR fixes the issue.

`module` is also not well-supported according to https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for so replace `module` with `exports` and ensure all referenced paths are relative.